### PR TITLE
Add `requirements.txt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 
 ### Running the models
 
-The script [iree.sh](scripts/iree.sh) is responsible to convert a model from ONNX to torch MLIR, and compile and run this converted model using the IREE compiler. The script assumes the IREE compiler is installed inside a Python environment located in a folder called `venv` in this repository. If this is not the case, you must:
+The script [iree.sh](scripts/iree.sh) is responsible to convert a model from ONNX to torch MLIR, and compile and run this converted model using the IREE compiler. The script assumes the IREE compiler is installed inside a Python environment located in a folder called `venv` in this repository, with all the necessary dependencies installed (the `requirements.txt` file contains the necessary dependencies for this).
+If this is not the case, you must:
 - If IREE is installed inside a Python environment, set the variable `PYTHON_VENV_PATH`
 - If IREE is built from source out of the `$PATH` environment variable, set the variables `IREE_IMPORT_ONNX`, `IREE_COMPILE` and `IREE_RUN_MODULE`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+iree-base-compiler==3.11.0
+iree-base-runtime==3.11.0
+ml_dtypes==0.5.4
+mpmath==1.3.0
+numpy==2.4.4
+onnx==1.21.0
+protobuf==7.34.1
+sympy==1.14.0
+typing_extensions==4.15.0


### PR DESCRIPTION
This pull request updates the documentation to clarify the dependencies required for running the model conversion and compilation script. The main change is an improvement to the instructions in the `README.md` regarding the Python environment and required dependencies.

Documentation improvements:

* Clarified that the `venv` Python environment must have all necessary dependencies installed, as specified in `requirements.txt`, for the `iree.sh` script to work properly.